### PR TITLE
Get mailbox

### DIFF
--- a/PolarisO365.ps1
+++ b/PolarisO365.ps1
@@ -315,6 +315,7 @@ function Get-PolarisO365Mailboxes() {
     id                          : 12341234-1234-1234-abcd-123456789012
     userPrincipalName           : milan.kundera@mydomain.onmicrosoft.com
     slaAssignment               : Direct
+    effectiveSlaDomainName      : Gold
     #>
 
     param(
@@ -352,24 +353,24 @@ function Get-PolarisO365Mailboxes() {
                         }
                         slaAssignment
                     }
-                    }
-                    pageInfo {
-                        endCursor
-                        hasNextPage
-                        hasPreviousPage
-                    }
                 }
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                    hasPreviousPage
+                }
+            }
         }";
         "variables"     = @{
             "after"     = $null;
             "filter"    = @(
                 @{
                     "field" = "IS_RELIC";
-                    "texts" = @("false")
+                    "texts" = @("false");
                 };
             )
             "first"     = 100;
-            "orgId"        = $SubscriptionId;
+            "orgId"     = $SubscriptionId;
             "sortBy"    = "EMAIL_ADDRESS";
             "sortOrder" = "ASC";
         }
@@ -479,20 +480,20 @@ function Get-PolarisO365Mailbox() {
                         }
                         slaAssignment
                     }
-                    }
-                    pageInfo {
-                        endCursor
-                        hasNextPage
-                        hasPreviousPage
-                    }
                 }
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                    hasPreviousPage
+                }
+            }
         }";
         "variables"     = @{
             "after"     = $null;
             "filter"    = @(
                 @{
                     "field" = "IS_RELIC";
-                    "texts" = @("false")
+                    "texts" = @("false");
                 },
                 @{
                     "field" = "NAME_OR_EMAIL_ADDRESS";
@@ -500,7 +501,7 @@ function Get-PolarisO365Mailbox() {
                 }
             );
             "first"     = 100;
-            "orgId"        = $SubscriptionId;
+            "orgId"     = $SubscriptionId;
             "sortBy"    = "EMAIL_ADDRESS";
             "sortOrder" = "ASC";
         }

--- a/PolarisO365.ps1
+++ b/PolarisO365.ps1
@@ -277,15 +277,15 @@ function Get-PolarisO365Subscriptions {
     return $org_details
 }
 
-function Get-PolarisO365Users() {
+function Get-PolarisO365Mailboxes() {
     <#
     .SYNOPSIS
 
-    Returns all O365 users for a given subscription in a given Polaris instance.
+    Returns all O365 mailboxes for a given subscription in a given Polaris instance.
 
     .DESCRIPTION
 
-    Returns an array of Office 365 users from a given subscription and Polaris instance, taking
+    Returns an array of Office 365 mailboxes from a given subscription and Polaris instance, taking
     an API token, Polaris URL, and subscription ID.
 
     .PARAMETER Token
@@ -300,22 +300,21 @@ function Get-PolarisO365Users() {
 
     .INPUTS
 
-    None. You cannot pipe objects to Get-PolarisO365Users.
+    None. You cannot pipe objects to Get-PolarisO365Mailboxes.
 
     .OUTPUTS
 
-    System.Object. Get-PolarisO365Users returns an array containing the ID, Name,
-    email address, and SLA details for the returned O365 users.
+    System.Object. Get-PolarisO365Mailboxes returns an array containing the ID, Name,
+    email address, and SLA details for the returned O365 mailboxes.
 
     .EXAMPLE
 
-    PS> Get-PolarisO365Users -Token $token -PolarisURL $url -SubscriptionId $my_sub.id
+    PS> Get-PolarisO365Mailboxes -Token $token -PolarisURL $url -SubscriptionId $my_sub.id
 
-    name                   : Milan Kundera
-    id                     : 12341234-1234-1234-abcd-123456789012
-    emailAddress           : milan.kundera@mydomain.onmicrosoft.com
-    slaAssignment          : Direct
-    effectiveSlaDomainName : Gold
+    name                        : Milan Kundera
+    id                          : 12341234-1234-1234-abcd-123456789012
+    userPrincipalName           : milan.kundera@mydomain.onmicrosoft.com
+    slaAssignment               : Direct
     #>
 
     param(
@@ -340,21 +339,19 @@ function Get-PolarisO365Users() {
     $node_array = @()
 
     $payload = @{
-        "operationName" = "O365UserList";
-        "query"         = "query O365UserList(`$first: Int!, `$after: String, `$id: UUID!, `$filter: [Filter!]!, `$sortBy: HierarchySortByField, `$sortOrder: HierarchySortOrder) {
-            o365Org(fid: `$id) {
-                id
-                childConnection(first: `$first, filter: `$filter, sortBy: `$sortBy, sortOrder: `$sortOrder, after: `$after) {
-                    edges {
-                        node {
-                            id
+        "operationName" = "O365MailboxList";
+        "query"         = "query O365MailboxList(`$first: Int!, `$after: String, `$orgId: UUID!, `$filter: [Filter!]!, `$sortBy: HierarchySortByField, `$sortOrder: HierarchySortOrder) {
+            o365Mailboxes(o365OrgId: `$orgId, after: `$after, first: `$first, filter: `$filter, sortBy: `$sortBy, sortOrder: `$sortOrder) {
+                edges {
+                    node {
+                        id
+                        name
+                        userPrincipalName
+                        effectiveSlaDomain {
                             name
-                            emailAddress
-                            effectiveSlaDomain {
-                                name
-                            }
-                            slaAssignment
                         }
+                        slaAssignment
+                    }
                     }
                     pageInfo {
                         endCursor
@@ -362,7 +359,6 @@ function Get-PolarisO365Users() {
                         hasPreviousPage
                     }
                 }
-            }
         }";
         "variables"     = @{
             "after"     = $null;
@@ -373,44 +369,44 @@ function Get-PolarisO365Users() {
                 };
             )
             "first"     = 100;
-            "id"        = $SubscriptionId;
+            "orgId"        = $SubscriptionId;
             "sortBy"    = "EMAIL_ADDRESS";
             "sortOrder" = "ASC";
         }
     }
     $response = Invoke-RestMethod -Method POST -Uri $endpoint -Body $($payload | ConvertTo-JSON -Depth 100) -Headers $headers
-    $node_array += $response.data.o365Org.childConnection.edges.node
+    $node_array += $response.data.o365Mailboxes.edges
     # get all pages of results
-    while ($response.data.o365Org.childConnection.pageInfo.hasNextPage) {
-        $payload.variables.after = $response.data.o365Org.childConnection.pageInfo.endCursor
+    while ($response.data.o365Mailboxes.pageInfo.hasNextPage) {
+        $payload.variables.after = $response.data.o365Mailboxes.pageInfo.endCursor
         $response = Invoke-RestMethod -Method POST -Uri $endpoint -Body $($payload | ConvertTo-JSON -Depth 100) -Headers $headers
-        $node_array += $response.data.o365Org.childConnection.edges.node
+        $node_array += $response.data.o365Mailboxes.edges
     }
 
-    $user_details = @()
+    $mailbox_details = @()
 
     foreach ($node in $node_array) {
-        $row = '' | Select-Object name, id, emailAddress, slaAssignment, effectiveSlaDomainName
-        $row.name = $node.name
-        $row.id = $node.id
-        $row.emailAddress = $node.emailAddress
-        $row.slaAssignment = $node.slaAssignment
-        $row.effectiveSlaDomainName = $node.effectiveSlaDomain.name
-        $user_details += $row
+        $row = '' | Select-Object name, id, userPrincipalName, slaAssignment, effectiveSlaDomainName
+        $row.name = $node.node.name
+        $row.id = $node.node.id
+        $row.userPrincipalName = $node.node.userPrincipalName
+        $row.slaAssignment = $node.node.slaAssignment
+        $row.effectiveSlaDomainName = $node.node.effectiveSlaDomain.name
+        $mailbox_details += $row
     }
 
-    return $user_details
+    return $mailbox_details
 }
 
-function Get-PolarisO365User() {
+function Get-PolarisO365Mailbox() {
     <#
     .SYNOPSIS
 
-    Returns a filtered list of O365 users for a given subscription in a given Polaris instance.
+    Returns a filtered list of O365 mailboxes for a given subscription in a given Polaris instance.
 
     .DESCRIPTION
 
-    Returns a filtered list of Office 365 users from a given subscription and Polaris instance, taking
+    Returns a filtered list of Office 365 mailboxes from a given subscription and Polaris instance, taking
     an API token, Polaris URL, subscription ID, and search string.
 
     .PARAMETER Token
@@ -424,20 +420,20 @@ function Get-PolarisO365User() {
     'Get-PolarisO365Subscriptions' command.
 
     .PARAMETER SearchString
-    Search string, used to filter user's name or email address.
+    Search string, used to filter mailbox's name or user principal name.
 
     .INPUTS
 
-    None. You cannot pipe objects to Get-PolarisO365User.
+    None. You cannot pipe objects to Get-PolarisO365Mailbox.
 
     .OUTPUTS
 
-    System.Object. Get-PolarisO365User returns an array containing the ID, Name,
-    email address, and SLA details for the returned O365 users.
+    System.Object. Get-PolarisO365Mailbox returns an array containing the ID, Name,
+    email address, and SLA details for the returned O365 mailboxes.
 
     .EXAMPLE
 
-    PS> Get-PolarisO365User -Token $token -PolarisURL $url -SubscriptionId $my_sub.id -SearchString 'Milan'
+    PS> Get-PolarisO365Mailbox -Token $token -PolarisURL $url -SubscriptionId $my_sub.id -SearchString 'Milan'
 
     name                   : Milan Kundera
     id                     : 12341234-1234-1234-abcd-123456789012
@@ -470,37 +466,19 @@ function Get-PolarisO365User() {
     $node_array = @()
 
     $payload = @{
-        "operationName" = "O365UserList";
-        "variables"     = @{
-            "id"        = $SubscriptionId;
-            "first"     = 100;
-            "filter"    = @(
-                @{
-                    "field" = "IS_RELIC";
-                    "texts" = @("false");
-                },
-                @{
-                    "field" = "NAME_OR_EMAIL_ADDRESS";
-                    "texts" = @($SearchString);
-                }
-            );
-            "sortBy"    = "EMAIL_ADDRESS";
-            "sortOrder" = "ASC";
-        };
-        "query"         = "query O365UserList(`$first: Int!, `$after: String, `$id: UUID!, `$filter: [Filter!]!, `$sortBy: HierarchySortByField, `$sortOrder: HierarchySortOrder) {
-            o365Org(fid: `$id) {
-                id
-                childConnection(first: `$first, filter: `$filter, sortBy: `$sortBy, sortOrder: `$sortOrder, after: `$after) {
-                    edges {
-                        node {
-                            id
+        "operationName" = "O365MailboxList";
+        "query"         = "query O365MailboxList(`$first: Int!, `$after: String, `$orgId: UUID!, `$filter: [Filter!]!, `$sortBy: HierarchySortByField, `$sortOrder: HierarchySortOrder) {
+            o365Mailboxes(o365OrgId: `$orgId, after: `$after, first: `$first, filter: `$filter, sortBy: `$sortBy, sortOrder: `$sortOrder) {
+                edges {
+                    node {
+                        id
+                        name
+                        userPrincipalName
+                        effectiveSlaDomain {
                             name
-                            emailAddress
-                            effectiveSlaDomain {
-                                name
-                            }
-                            slaAssignment
                         }
+                        slaAssignment
+                    }
                     }
                     pageInfo {
                         endCursor
@@ -508,31 +486,47 @@ function Get-PolarisO365User() {
                         hasPreviousPage
                     }
                 }
-            }
-        }"
+        }";
+        "variables"     = @{
+            "after"     = $null;
+            "filter"    = @(
+                @{
+                    "field" = "IS_RELIC";
+                    "texts" = @("false")
+                },
+                @{
+                    "field" = "NAME_OR_EMAIL_ADDRESS";
+                    "texts" = @($SearchString);
+                }
+            );
+            "first"     = 100;
+            "orgId"        = $SubscriptionId;
+            "sortBy"    = "EMAIL_ADDRESS";
+            "sortOrder" = "ASC";
+        }
     }
     $response = Invoke-RestMethod -Method POST -Uri $endpoint -Body $($payload | ConvertTo-JSON -Depth 100) -Headers $headers
-    $node_array += $response.data.o365Org.childConnection.edges.node
+    $node_array += $response.data.o365Mailboxes.edges
     # get all pages of results
-    while ($response.data.o365Org.childConnection.pageInfo.hasNextPage) {
-        $payload.variables.after = $response.data.o365Org.childConnection.pageInfo.endCursor
+    while ($response.data.o365Mailboxes.pageInfo.hasNextPage) {
+        $payload.variables.after = $response.data.o365Mailboxes.pageInfo.endCursor
         $response = Invoke-RestMethod -Method POST -Uri $endpoint -Body $($payload | ConvertTo-JSON -Depth 100) -Headers $headers
-        $node_array += $response.data.o365Org.childConnection.edges.node
+        $node_array += $response.data.o365Mailboxes.edges
     }
 
-    $user_details = @()
+    $mailbox_details = @()
 
     foreach ($node in $node_array) {
-        $row = '' | Select-Object name, id, emailAddress, slaAssignment, effectiveSlaDomainName
-        $row.name = $node.name
-        $row.id = $node.id
-        $row.emailAddress = $node.emailAddress
-        $row.slaAssignment = $node.slaAssignment
-        $row.effectiveSlaDomainName = $node.effectiveSlaDomain.name
-        $user_details += $row
+        $row = '' | Select-Object name, id, userPrincipalName, slaAssignment, effectiveSlaDomainName
+        $row.name = $node.node.name
+        $row.id = $node.node.id
+        $row.userPrincipalName = $node.node.userPrincipalName
+        $row.slaAssignment = $node.node.slaAssignment
+        $row.effectiveSlaDomainName = $node.node.effectiveSlaDomain.name
+        $mailbox_details += $row
     }
 
-    return $user_details
+    return $mailbox_details
 }
 
 function Set-PolarisO365ObjectSla() {

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -42,8 +42,8 @@ The following commands are available in the module:
 * `Get-PolarisToken`
 * `Get-PolarisSLA`
 * `Get-PolarisO365Subscriptions`
-* `Get-PolarisO365Users`
-* `Get-PolarisO365User`
+* `Get-PolarisO365Mailboxes`
+* `Get-PolarisO365Mailbox`
 * `Set-PolarisO365ObjectSla`
 
 Each command has help which describes their usage and parameters, these can be seen using the `Get-Help <command>` command within PowerShell.
@@ -72,11 +72,11 @@ $my_sub = $all_subs | ?{$_.name -eq $sub_name}
 # get our SLA domain
 $my_sla = Get-PolarisSLA -Token $token -PolarisURL $url -Name $sla_name
 
-# get our user
-$my_user = Get-PolarisO365User -Token $token -PolarisURL $url -SubscriptionId $my_sub.id -SearchString 'arif'
+# get our mailbox user
+$my_mailbox = Get-PolarisO365Mailbox -Token $token -PolarisURL $url -SubscriptionId $my_sub.id -SearchString 'arif'
 
-# set the SLA domain for our user
-Set-PolarisO365ObjectSla -Token $token -PolarisURL $url -ObjectID $my_user.id -SLAID $my_sla.id
+# set the SLA domain for our mailbox user
+Set-PolarisO365ObjectSla -Token $token -PolarisURL $url -ObjectID $my_mailbox.id -SLAID $my_sla.id
 
 # or set the SLA domain of our subscription
 Set-PolarisO365ObjectSla -Token $token -PolarisURL $url -ObjectID $my_sub.id -SLAID $my_sla.id
@@ -92,15 +92,15 @@ $all_orgs = Get-PolarisO365Subscriptions -Token $token -PolarisURL $url
 $my_org = $all_orgs | ?{$_.name -eq $org_name}
 $all_slas = Get-PolarisSLA -Token $token -PolarisURL $url
 $my_sla = $all_slas | ?{$_.name -eq 'Gold'}
-$all_users = Get-PolarisO365Users -Token $token -PolarisURL $url -SubscriptionId $my_org.id
-$500_users = $all_users | select -First 500
-$assign = Set-PolarisO365ObjectSla -Token $token -PolarisURL $url -ObjectID $500_users.id -SlaID $my_sla.id
+$all_mailboxes = Get-PolarisO365Mailboxes -Token $token -PolarisURL $url -SubscriptionId $my_org.id
+$500_mailboxes = $all_mailboxes | select -First 500
+$assign = Set-PolarisO365ObjectSla -Token $token -PolarisURL $url -ObjectID $500_mailboxes.id -SlaID $my_sla.id
 ```
 
 The key line here is this:
 
 ```powershell
-$500_users = $all_users | select -First 500
+$500_mailboxes = $all_mailboxes | select -First 500
 ```
 
-Here we are just picking the first 500 accounts, but more specific selection could be achieved using standard PowerShell filtering on the `$all_users` array.
+Here we are just picking the first 500 accounts, but more specific selection could be achieved using standard PowerShell filtering on the `$all_mailboxes` array.


### PR DESCRIPTION
# Description

With the change in O365 backend, now assigning SLA users will be blocked explicitly. This change makes sure the user of this script retrieves mailbox objects from Polaris instead of user objects.

## Related Issue

N/A

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested locally by running script against dev environment
## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.