### PR TITLE
Use the right query to list SharePoint sites and document libraries

### DIFF
--- a/PolarisO365.ps1
+++ b/PolarisO365.ps1
@@ -789,7 +789,7 @@ function Get-PolarisO365SharePoint() {
     None. You cannot pipe objects to Get-PolarisO365SharePoint.
     .OUTPUTS
     System.Object. Get-PolarisO365SharePoint returns an array containing the ID, Name,
-    email address, and SLA details for the returned O365 OneDrive users.
+    and SLA details for the returned O365 SharePoint sites and/or document libraries.
     .EXAMPLE
     PS> Get-PolarisO365SharePoint -Token $token -PolarisURL $url -SubscriptionId $my_sub.id
     name                   : Milan Kundera

--- a/PolarisO365.ps1
+++ b/PolarisO365.ps1
@@ -891,21 +891,21 @@ function Get-PolarisO365SharePoint() {
     }"
 
     if ($Includes -eq "SitesOnly") {
-        $payload.query = "query O365SharepointObjectQuery(`$after: String, `$o365OrgId:UUID!, `$filter: [Filter!], `$first: Int!, `$sortBy: HierarchySortByField, `$sortOrder: HierarchySortOrder) {
+        $payload.query = "query O365SharepointQuery(`$after: String, `$o365OrgId:UUID!, `$filter: [Filter!], `$first: Int!, `$sortBy: HierarchySortByField, `$sortOrder: HierarchySortOrder) {
             $($querySites)
         }"
  
         $response = Invoke-RestMethod -Method POST -Uri $endpoint -Body $($payload | ConvertTo-JSON -Depth 100) -Headers $headers
         $o365Sites = $response.data.o365Sites
     } elseif ($Includes -eq "DocumentLibrariesOnly") {
-        $payload.query = "query o365SharepointDrives(`$after: String, `$o365OrgId:UUID!, `$filter: [Filter!], `$first: Int!, `$sortBy: HierarchySortByField, `$sortOrder: HierarchySortOrder) {
+        $payload.query = "query O365SharepointQuery(`$after: String, `$o365OrgId:UUID!, `$filter: [Filter!], `$first: Int!, `$sortBy: HierarchySortByField, `$sortOrder: HierarchySortOrder) {
             $($queryDrives)
         }"
 
         $response = Invoke-RestMethod -Method POST -Uri $endpoint -Body $($payload | ConvertTo-JSON -Depth 100) -Headers $headers
         $o365SharepointDrives = $response.data.o365SharepointDrives
     } else {
-        $payload.query = "query o365SharepointDrives(`$after: String, `$o365OrgId:UUID!, `$filter: [Filter!], `$first: Int!, `$sortBy: HierarchySortByField, `$sortOrder: HierarchySortOrder) {
+        $payload.query = "query O365SharepointQuery(`$after: String, `$o365OrgId:UUID!, `$filter: [Filter!], `$first: Int!, `$sortBy: HierarchySortByField, `$sortOrder: HierarchySortOrder) {
             $($querySites)
             $($queryDrives)
         }"

--- a/PolarisO365.ps1
+++ b/PolarisO365.ps1
@@ -784,7 +784,8 @@ function Get-PolarisO365SharePoint() {
     .PARAMETER SearchString
     Search string, used to filter site or document library name.
     .PARAMETER Includes
-    It indidates if the returned object includes only SharePoint sites, document libraries or both. The value can only be 'SitesOnly', 'DocumentLibrariesOnly' or 'Both'.
+    It indidates if the returned object includes only SharePoint sites, document libraries or both. The value can only be 'SitesOnly', 'DocumentLibrariesOnly'.
+    if it's not specified, it returns both sites and document libraries by default.
     .INPUTS
     None. You cannot pipe objects to Get-PolarisO365SharePoint.
     .OUTPUTS
@@ -809,7 +810,7 @@ function Get-PolarisO365SharePoint() {
         [Parameter(Mandatory=$false)]
         [String]$SearchString,
         [Parameter(Mandatory=$false)]
-        [ValidateSet("SitesOnly", "DocumentLibrariesOnly", "Both")]
+        [ValidateSet("SitesOnly", "DocumentLibrariesOnly")]
         [String]$Includes
     )
 
@@ -840,8 +841,6 @@ function Get-PolarisO365SharePoint() {
             );
             "first"     = 100;
             "o365OrgId" = $SubscriptionId;
-            "sortBy"    = "EMAIL_ADDRESS";
-            "sortOrder" = "ASC";
         }
     }
 

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -46,6 +46,7 @@ The following commands are available in the module:
 * `Get-PolarisO365Mailbox`
 * `Get-PolarisO365OneDrives`
 * `Get-PolarisO365OneDrive`
+* `Get-PolarisO365SharePoint`
 * `Set-PolarisO365ObjectSla`
 
 Each command has help which describes their usage and parameters, these can be seen using the `Get-Help <command>` command within PowerShell.
@@ -79,6 +80,9 @@ $my_mailbox = Get-PolarisO365Mailbox -Token $token -PolarisURL $url -Subscriptio
 
 # get our onedrive user
 $my_onedrive = Get-PolarisO365OneDrive -Token $token -PolarisURL $url -SubscriptionId $my_sub.id -SearchString 'arif'
+
+# get our SharePoint sites
+$my_sharepoint = Get-PolarisO365SharePoint -Token $token -PolarisURL $url -SubscriptionId $my_sub.id -SearchString 'arif' - Includes 'SitesOnly'
 
 # set the SLA domain for our mailbox user
 Set-PolarisO365ObjectSla -Token $token -PolarisURL $url -ObjectID $my_mailbox.id -SLAID $my_sla.id

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -82,7 +82,13 @@ $my_mailbox = Get-PolarisO365Mailbox -Token $token -PolarisURL $url -Subscriptio
 $my_onedrive = Get-PolarisO365OneDrive -Token $token -PolarisURL $url -SubscriptionId $my_sub.id -SearchString 'arif'
 
 # get our SharePoint sites
-$my_sharepoint = Get-PolarisO365SharePoint -Token $token -PolarisURL $url -SubscriptionId $my_sub.id -SearchString 'arif' - Includes 'SitesOnly'
+$my_sharepoint_sites = Get-PolarisO365SharePoint -Token $token -PolarisURL $url -SubscriptionId $my_sub.id -SearchString 'arif' - Includes 'SitesOnly'
+
+# get our SharePoint document libraries
+$my_sharepoint_libraries = Get-PolarisO365SharePoint -Token $token -PolarisURL $url -SubscriptionId $my_sub.id -SearchString 'arif' - Includes 'DocumentLibrariesOnly'
+
+# get our SharePoint sites and document libraries
+$my_sharepoint_both = Get-PolarisO365SharePoint -Token $token -PolarisURL $url -SubscriptionId $my_sub.id -SearchString 'arif'
 
 # set the SLA domain for our mailbox user
 Set-PolarisO365ObjectSla -Token $token -PolarisURL $url -ObjectID $my_mailbox.id -SLAID $my_sla.id


### PR DESCRIPTION
# Description

The query in my previous change (https://github.com/rubrikinc/polaris-o365-powershell/pull/16) can only list direct site children of a subscription, but can't list sites and document libraries recursively.

It uses the right query to list all sites and/or document libraries of a subscription, including the embedded ones.

## Related Issue

The query in my previous change (https://github.com/rubrikinc/polaris-o365-powershell/pull/16) can only list direct site children of a subscription, but can't list sites and document libraries recursively.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Manual tests

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.