### PR TITLE
Update SLA assignment GQL

### DIFF
--- a/RubrikPolaris/M365/Set-PolarisM365ObjectSla.ps1
+++ b/RubrikPolaris/M365/Set-PolarisM365ObjectSla.ps1
@@ -68,7 +68,13 @@ function Set-PolarisM365ObjectSla() {
             "objectIds"            = $ObjectID;
         };
         "query"         = "mutation AssignSLA(`$globalSlaOptionalFid: UUID, `$globalSlaAssignType: SlaAssignTypeEnum!, `$objectIds: [UUID!]!) {
-            assignSla(globalSlaOptionalFid: `$globalSlaOptionalFid, globalSlaAssignType: `$globalSlaAssignType, objectIds: `$objectIds) {
+            assignSla(
+                input : {
+                    slaOptionalId: `$globalSlaOptionalFid,
+                    slaDomainAssignType: `$globalSlaAssignType, 
+                    objectIds: `$objectIds
+                }
+            ) {
                 success
             }
         }";


### PR DESCRIPTION
# Description

The SLA assignment GraphQL endpoint was changed on Polaris, breaking the script. 

## Related Issue

## Motivation and Context

SLA assignment is failing due to invalid fields.

## How Has This Been Tested?

Verified using pwsh for mac

PS /Users/ameliavu/polaris-o365-powershell/RubrikPolaris/M365> Import-Module ../RubrikPolaris.psd1
PS /Users/ameliavu/polaris-o365-powershell/RubrikPolaris/M365> Connect-Polaris
PS /Users/ameliavu/polaris-o365-powershell/RubrikPolaris/M365> Set-PolarisM365ObjectSla  -ObjectID '5f644256-bb93-4e96-96bd-5d897cfd62f0' -SlaID 'DONOTPROTECT'

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.