### PR TITLE
Added User.Read into scopes for Connect-Graph

### DIFF
--- a/RubrikPolaris/M365/New-EnterpriseApplication.ps1
+++ b/RubrikPolaris/M365/New-EnterpriseApplication.ps1
@@ -200,7 +200,7 @@ function New-EnterpriseApplication() {
     } 
 
     Write-Information -Message "Info: Connecting to the Microsoft Graph API using the 'Application.ReadWrite.All' and 'AppRoleAssignment.ReadWrite.All' Scope."
-    Connect-Graph -Scopes "Application.ReadWrite.All","AppRoleAssignment.ReadWrite.All" -ErrorAction Stop | Out-Null
+    Connect-Graph -Scopes "Application.ReadWrite.All","AppRoleAssignment.ReadWrite.All","User.Read" -ErrorAction Stop | Out-Null
     Write-Information -Message "Info: Successfully authenticated the Microsoft Graph API."
 
     foreach ($source in $toCreateDetails.GetEnumerator()) {


### PR DESCRIPTION
# Description

<!-- Please describe your pull request in detail.-->

## Related Issue

<!-- Please link to the issue here-->
https://github.com/rubrikinc/polaris-o365-powershell/issues/29

<!-- If no issue exsits for your pull request, please use a draft pull requests for discussion purposes-->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

The cmdlet `Get-MgOrganization` cannot be called without the proper permissions. `User.Read` is the lowest level permission to run the cmdlet. It's not required to specify `User.Read` when connecting to MS Graph, but the permission needs to be consented to.
By directly specifying this permission in the scopes when connecting, the user will be prompted to grant consent for the permission.

## How Has This Been Tested?

<!-- * Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.-->

Tested by running `Connect-MgGraph -Scopes "Application.ReadWrite.All"`, with no permissions already consented to. Running `Get-MgOrganization` fails due to insufficient privileges.

Reconnecting with `Connect-MgGraph -Scopes "Application.ReadWrite.All", "User.Read"` allows the cmdlet `Get-MgOrganization` to be run succesfully

Reconnecting with `Connect-MgGraph` with no scopes, the cmdlet `Get-MgOrganization` still runs as `User.Read` permission has already been consented to

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/48874569/180481841-1368cb2b-ef56-401a-96db-479b2381b9a0.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.