### PR TITLE
Remove currentStep when not in progress

### DIFF
--- a/RubrikPolaris/M365/Get-MassRecoveryProgress.ps1
+++ b/RubrikPolaris/M365/Get-MassRecoveryProgress.ps1
@@ -100,12 +100,16 @@ function Get-MassRecoveryProgress() {
     $respProgress.endTime = getDateTime($respProgress.endTime)
     $respProgress.elapsedTime = getTime($respProgress.elapsedTime)
 
-    if ($respProgress.status -eq "Canceled") {
+    if ($respProgress.status -eq "CANCELED") {
       $respProgress.failureReason = ""
       $cancelObjects = $respProgress.totalObjects - $respProgress.inProgressObjects - 
         $respProgress.succeededObjects - $respProgress.failedObjects
       
       $respProgress | Add-Member NoteProperty canceledObjects($cancelObjects)
+    }
+
+    if ($respProgress.status -ne "IN_PROGRESS") {
+        $respProgress.PSObject.Properties.Remove('currentStep')
     }
 
     $respProgress.failureActionType = "IGNORE_AND_CONTINUE"


### PR DESCRIPTION
# Description

Removes the current step when mass recovery is not in progress, as showing this information to the user does not make sense.

## Related Issue

Closes #36

## How Has This Been Tested?

Manual Testing

## Screenshots (if appropriate):

Canceled/Succeeded:
<img width="1385" alt="Screenshot 2023-03-28 at 3 13 19 PM" src="https://user-images.githubusercontent.com/49281840/228474164-defe99c4-db86-49c7-8c8b-47194e3d962a.png">
<img width="1391" alt="Screenshot 2023-03-28 at 3 13 13 PM" src="https://user-images.githubusercontent.com/49281840/228474217-cc65c0b2-235b-4f07-9ae3-69f80169eb3f.png">

In Progress:
<img width="1383" alt="Screenshot 2023-03-28 at 3 13 07 PM" src="https://user-images.githubusercontent.com/49281840/228474249-9672ccfc-81ed-45a4-a85a-4d8300860ec0.png">


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.