### PR TITLE
Add SharePoint mass recovery support

### DIFF
--- a/RubrikPolaris/M365/Get-MassRecoveryProgress.ps1
+++ b/RubrikPolaris/M365/Get-MassRecoveryProgress.ps1
@@ -54,6 +54,7 @@ function Get-MassRecoveryProgress() {
         "query"         = "query BulkRecoveryProgress(`$input: BulkRecoveryProgressInput!) {
             bulkRecoveryProgress(input: `$input) {
               recoveryPlanName
+              createTime
               startTime
               endTime
               elapsedTime
@@ -61,6 +62,7 @@ function Get-MassRecoveryProgress() {
               failedObjects
               succeededObjects
               inProgressObjects
+              objectsWithoutSnapshot
               totalObjects
               groupsProcessed
               totalGroups
@@ -102,9 +104,6 @@ function Get-MassRecoveryProgress() {
 
     if ($respProgress.status -eq "CANCELED") {
       $respProgress.failureReason = ""
-      $cancelObjects = $respProgress.totalObjects - $respProgress.inProgressObjects - 
-        $respProgress.succeededObjects - $respProgress.failedObjects
-      
       $respProgress | Add-Member NoteProperty canceledObjects($cancelObjects)
     }
 
@@ -130,7 +129,7 @@ function Get-MassRecoveryProgress() {
 
 function getDateTime($unixTimeStamp) {
   if ($null -eq $unixTimeStamp) {
-    return "null"
+    return ""
   }
 
   $epochStart = Get-Date 01.01.1970


### PR DESCRIPTION
# Description

This PR adds support for Sharepoint Mass Recovery.

## Motivation and Context

It adds support for Sharepoint Mass Recovery, by giving users an option to provide `ConfiguredGroupName` and `WorkloadType` as `Sharepoint`.

## How Has This Been Tested?

Tested on dev deployment dev-079, and running the commands after setting up service account.

## Screenshots (if appropriate):

```
PS /Users/Rishabh.Singhal/Developement/polaris-o365-powershell> Start-MassRecovery -Name "BR_Sharpoint_TEST" -RecoveryPoint "07/10/23 16:30:00" -SubscriptionName "RDNN14" -ConfiguredGroupName "A public team - gjgjhhjg" -WorkloadType "Sharepoint" 

Started mass recovery BR_Sharpoint_TEST_Sharepoint with the following details:
@{massRecoveryInstanceID=298558e9-de31-4dbf-9498-971a7b4e9846; taskchainID=06f3ed28-c2dd-4a4e-93cc-5049f8a69b93; jobID=34; error=}
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.