### PR TITLE
Breaking changes for mass recovery endpoints

### DIFF
--- a/RubrikPolaris/M365/Get-MassRecoveryProgress.ps1
+++ b/RubrikPolaris/M365/Get-MassRecoveryProgress.ps1
@@ -11,6 +11,9 @@ function Get-MassRecoveryProgress() {
     .PARAMETER MassRecoveryInstanceId
     The instance ID of mass recovery you wish to check progress.
 
+    .PARAMETER SubscriptionName
+    The subscription name for the mass recovery you wish to check progress.
+
     .INPUTS
     None. You cannot pipe objects to Get-MassRecoveryProgress.
    
@@ -19,12 +22,14 @@ function Get-MassRecoveryProgress() {
     of failed, in progress, canceled, succeeded, total restore onedrive objects, etc. 
    
     .EXAMPLE
-    PS> Get-MassRecoveryProgress -MassRecoveryInstanceId $massRecoveryInstanceId
+    PS> Get-MassRecoveryProgress -MassRecoveryInstanceId $massRecoveryInstanceId -SubscriptionName $subscriptionName
     #>
 
     param(
         [Parameter(Mandatory=$True)]
         [String]$MassRecoveryInstanceId,
+        [Parameter(Mandatory=$True)]
+        [String]$SubscriptionName,
         [String]$Token = $global:RubrikPolarisConnection.accessToken,
         [String]$PolarisURL = $global:RubrikPolarisConnection.PolarisURL
     )
@@ -44,11 +49,14 @@ function Get-MassRecoveryProgress() {
 
     Write-Host -Message "Fetching progress for mass recovery with instance ID $MassRecoveryInstanceId."
 
+    $subscriptionId = getSubscriptionId($SubscriptionName)
+
     $payload = @{
         "operationName" = "BulkRecoveryProgress";
         "variables"     = @{
             "input" = @{
               "bulkRecoveryInstanceId" = $MassRecoveryInstanceId;
+              "subscriptionId" = $subscriptionId;
             };
           };
         "query"         = "query BulkRecoveryProgress(`$input: BulkRecoveryProgressInput!) {
@@ -62,6 +70,7 @@ function Get-MassRecoveryProgress() {
               failedObjects
               succeededObjects
               inProgressObjects
+              canceledObjects
               objectsWithoutSnapshot
               totalObjects
               groupsProcessed
@@ -98,13 +107,20 @@ function Get-MassRecoveryProgress() {
 
     $respProgress = $response.data.bulkRecoveryProgress
 
+    $respProgress.createTime = getDateTime($respProgress.createTime)
     $respProgress.startTime = getDateTime($respProgress.startTime)
     $respProgress.endTime = getDateTime($respProgress.endTime)
     $respProgress.elapsedTime = getTime($respProgress.elapsedTime)
 
+    if ($respProgress.startTime -eq "") {
+      $respProgress.elapsedTime = ""
+    }
+
     if ($respProgress.status -eq "CANCELED") {
       $respProgress.failureReason = ""
       $respProgress | Add-Member NoteProperty canceledObjects($cancelObjects)
+    } else {
+      $respProgress.PSObject.Properties.Remove('canceledObjects')
     }
 
     if ($respProgress.status -ne "IN_PROGRESS") {
@@ -140,6 +156,43 @@ function getDateTime($unixTimeStamp) {
 function getTime($milliseconds) {
  $time = [System.TimeSpan]::frommilliseconds($milliseconds)
  return "$($time.Days) days, $($time.Hours) hours, $($time.Minutes) minutes, $($time.Seconds) seconds"
+}
+
+function getSubscriptionId($subscriptionName) {
+  $headers = @{
+    'Content-Type' = 'application/json';
+    'Accept' = 'application/json';
+    'Authorization' = $('Bearer '+$global:RubrikPolarisConnection.accessToken);
+  }
+
+  $endpoint = $global:RubrikPolarisConnection.PolarisURL + '/api/graphql'
+  $payload = @{
+      "operationName" = "O365Orgs";
+      "query" = "query O365Orgs {
+        o365Orgs {
+          nodes {
+            id
+            name
+          }
+        }
+      }";
+  }
+
+  $response = Invoke-RestMethod -Method POST -Uri $endpoint -Body $($payload | ConvertTo-JSON -Depth 100) -Headers $headers
+  $o365Orgs = $response.data.o365Orgs.nodes
+
+  $subscriptionIds = @()
+  $o365Orgs | ForEach-Object -Process {
+    if ($_.name -eq $subscriptionName) {
+      $subscriptionIds += $_.id
+    }
+  }
+
+  if ($subscriptionIds.Count -ne 1) {
+    throw "There exists zero or more than 1 subscriptions with name '$subscriptionName'." 
+  }
+
+  return $subscriptionIds[0]
 }
 
 Export-ModuleMember -Function Get-MassRecoveryProgress

--- a/RubrikPolaris/M365/Stop-MassRecovery.ps1
+++ b/RubrikPolaris/M365/Stop-MassRecovery.ps1
@@ -9,6 +9,9 @@ function Stop-MassRecovery() {
     .PARAMETER MassRecoveryInstanceId
     The instance ID of mass recovery you wish to stop.
 
+    .PARAMETER SubscriptionName
+    The subscription name for the mass recovery you wish to stop.
+
     .INPUTS
     None. You cannot pipe objects to Get-MassRecoveryProgress.
    
@@ -16,12 +19,14 @@ function Stop-MassRecovery() {
     System.Object. Stop-MassRecovery returns true in case it is success 
    
     .EXAMPLE
-    PS> Stop-MassRecovery -MassRecoveryInstanceId $massRecoveryInstanceId
+    PS> Stop-MassRecovery -MassRecoveryInstanceId $massRecoveryInstanceId -SubscriptionName $subscriptionName
     #>
 
     param(
         [Parameter(Mandatory=$True)]
         [String]$MassRecoveryInstanceId,
+        [Parameter(Mandatory=$True)]
+        [String]$SubscriptionName,
         [String]$Token = $global:RubrikPolarisConnection.accessToken,
         [String]$PolarisURL = $global:RubrikPolarisConnection.PolarisURL
     )
@@ -39,6 +44,8 @@ function Stop-MassRecovery() {
 
     $endpoint = $PolarisURL + '/api/graphql'
 
+    $subscriptionId = getSubscriptionId($SubscriptionName)
+
     Write-Information -Message "Stopping mass recovery with instance ID $MassRecoveryInstanceId."
 
     $payload = @{
@@ -46,6 +53,7 @@ function Stop-MassRecovery() {
         "variables"     = @{
             "input" = @{
               "bulkRecoveryInstanceId" = $MassRecoveryInstanceId;
+              "subscriptionId" = $subscriptionId;
             };
           };
         "query"         = "mutation CancelBulkRecovery(`$input: CancelBulkRecoveryInput!) {
@@ -83,7 +91,7 @@ function Test-IsGuid
         [Parameter(Mandatory = $true)]
         [string]$StringGuid
     )
- 
+
    $ObjectGuid = [System.Guid]::empty
    return [System.Guid]::TryParse($StringGuid,[System.Management.Automation.PSReference]$ObjectGuid) # Returns True if successfully parsed
 }


### PR DESCRIPTION
# Description

This PR adds the following changes:
1. Add support for subscription name alongside the mass recovery instance ID for stop and get-progress mass recovery endpoints.
2. Change 'SubSnappableName' to user-facing 'SubWorkloadType'


## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested with a bodega environment dev-112.
1. Tested the name change for SubSnappableName to SubWorkloadType. Now the endpoint does not support argument SubSnappableName.
2. Tested the conversion of subscription name into subscription ID in cases: No subscription with the name is present; 1 subscription exist; and more than 1 subscription exists.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
