### PR TITLE
Check only active m365 orgs

### DIFF
--- a/RubrikPolaris/M365/Get-MassRecoveryProgress.ps1
+++ b/RubrikPolaris/M365/Get-MassRecoveryProgress.ps1
@@ -183,7 +183,7 @@ function getSubscriptionId($subscriptionName) {
 
   $subscriptionIds = @()
   $o365Orgs | ForEach-Object -Process {
-    if ($_.name -eq $subscriptionName) {
+    if (($_.name -eq $subscriptionName) -and ($_.status -eq "ACTIVE")) {
       $subscriptionIds += $_.id
     }
   }


### PR DESCRIPTION
# Description

Check only active m365 orgs, right now we are checking all the orgs with the same name which could also include non-active/refreshing/deleting orgs.

## How Has This Been Tested?

Tested with bodega deployment.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)