### PR TITLE
Add Operational Recovery endpoints

### DIFF
--- a/RubrikPolaris/M365/Start-OperationalRecovery.ps1
+++ b/RubrikPolaris/M365/Start-OperationalRecovery.ps1
@@ -1,0 +1,211 @@
+function Start-OperationalRecovery() {
+    <#
+    .SYNOPSIS
+    Operational restore Exchange for an AD Group 
+    
+    .DESCRIPTION
+    Operational restore Exchange for an AD Group from latest backups before a
+    given recovery point in time using the mailboxTimeRange.
+
+    .PARAMETER Name
+    The name of the operational recovery you wish to choose. 
+
+    .PARAMETER RecoveryPoint
+    The date time you wish to use to restore closest earlier backups. The format
+    is "YYYY-MM-DD HH:MM:SS"
+    
+    .PARAMETER SubscriptionName
+    The subscription name you wish to operational restore under.
+   
+    .PARAMETER AdGroupId
+    The ID of the AD Group you wish to operational restore.
+
+    .PARAMETER WorkloadType
+    The type of workload you wish to mass restore, only "Exchange" is supported
+    right now.
+  
+    .PARAMETER MailboxFromTime
+    The date time you wish to use to retore the emails received after that. The
+    format is "YYYY-MM-DD HH:MM:SS"
+
+    .PARAMETER MailboxUntilTime
+    The date time you wish to use to retore the emails received before that. The
+    format is "YYYY-MM-DD HH:MM:SS"
+
+    .PARAMETER ArchiveFolderAction
+    The Action of archive folder you wish to use to restore mailbox.
+
+    .PARAMETER SubWorkloadType
+    The type of sub workload you wish to restore. Only supported for "Exchange"
+    workload type, where sub workload types are "Calendar", "Contacts" and "Mailbox"
+    
+    .INPUTS
+    None. You cannot pipe objects to Start-OperationalRecovery.
+   
+    .OUTPUTS
+    System.Object. The taskchainID, massRecoveryInstanceID, error and jobID for 
+    the mass recovery job.
+   
+    .EXAMPLE
+    PS> Start-OperationalRecovery -Name $name -RecoveryPoint $recoveryPoint -SubscriptionName $subscriptionName -AdGroupId $adGroupId -WorkloadType $workloadType -MailboxFromTime $mailboxFromTime -MailboxUntilTime $mailboxUntilTime
+    
+    PS> Start-OperationalRecovery -Name $name -RecoveryPoint $recoveryPoint -SubscriptionName $subscriptionName -AdGroupId $adGroupId -WorkloadType $workloadType -ArchiveFolderAction $archiveFolderAction 
+   
+    #>
+
+    param(
+        [Parameter(Mandatory=$True)]
+        [String]$Name,
+        [Parameter(Mandatory=$True)]
+        [DateTime]$RecoveryPoint,
+        [Parameter(Mandatory=$True)]
+        [String]$SubscriptionName,
+        [Parameter(Mandatory=$True)]
+        [String]$AdGroupId,
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Exchange")]
+        [String]$WorkloadType,
+        [Parameter(Mandatory=$False)]
+        [DateTime]$MailboxFromTime,
+        [Parameter(Mandatory=$False)]
+        [DateTime]$MailboxUntilTime,
+        [Parameter(Mandatory=$False)]
+        [ValidateSet("NO_ACTION", "EXCLUDE_ARCHIVE", "ARCHIVE_ONLY")]
+        [String]$ArchiveFolderAction,
+        [Parameter(Mandatory=$False)]
+        [ValidateSet("Mailbox", "Calendar", "Contacts")]
+        [String]$SubWorkloadType,
+        [String]$Token = $global:RubrikPolarisConnection.accessToken,
+        [String]$PolarisURL = $global:RubrikPolarisConnection.PolarisURL
+    )
+    
+    if (($SubWorkloadType -eq "Mailbox") -or ($SubWorkloadType -eq "")) {
+        if ($ArchiveFolderAction -eq "") {
+            $ArchiveFolderAction = "NO_ACTION"
+        }
+	if (($MailboxFromTime -eq $null) -and ($MailboxUntilTime -eq $null) -and ($ArchiveFolderAction -eq "NO_ACTION")) {
+	    Write-Host "Error starting operational recovery $Name. One of MailboxFromTime, MailboxUntilTime and ArchiveFolderAction should not be empty for Exchange Mailbox type.`n"
+            return
+	}
+    }    
+
+    $calendarFromTime = (Get-Date).AddDays(-14) | Get-Date -format s
+    Write-Host "Start Operational Recovery using MailboxTimeRange fromTime: $MailboxFromTime, untilTime: $MailboxUntilTime and CalendarTime Range fromTime: $calendarFromTime.`n"
+
+    $snappableToSubSnappableMap = @{
+        "Exchange" = @(
+            @{
+                SnappableType = "O365_EXCHANGE";
+                SubSnappableType = "O365_MAILBOX";
+                NameSuffix="Mailbox";
+                OperationalRecoverySpec = @{
+                    "mailboxOperationalRecoverySpec" = @{
+                        "mailboxTimeRange" = @{
+                            "fromTime" = $MailboxFromTime;
+                            "untilTime" = $MailboxUntilTime;
+                        };
+                        "archiveFolderAction" = $ArchiveFolderAction;
+		    }
+                };
+            };
+            @{
+                SnappableType = "O365_EXCHANGE";
+                SubSnappableType = "O365_CALENDAR";
+                NameSuffix="Calendar";
+                OperationalRecoverySpec = @{
+                    "calendarOperationalRecoverySpec" = @{
+                        "calendarTimeRange" = @{
+                            "fromTime" = $calendarFromTime 
+                        }; 
+                    };
+                };
+            };
+            @{
+                SnappableType = "O365_EXCHANGE";
+                SubSnappableType = "O365_CONTACT";
+                NameSuffix="Contacts";
+                OperationalRecoverySpec = $null;
+            };
+        );
+    }
+
+    $headers = @{
+        'Content-Type' = 'application/json';
+        'Accept' = 'application/json';
+        'Authorization' = $('Bearer '+$Token);
+    }
+
+    $endpoint = $PolarisURL + '/api/graphql'
+    $rpMilliseconds = ([DateTimeOffset]$RecoveryPoint).ToUnixTimeMilliseconds()   
+
+    Write-Information -Message "Starting the operational restoration process for $WorkloadType account(s) under AD Group ID $AdGroupId."
+  
+    $subscriptionId = getSubscriptionId($SubscriptionName)
+  
+    $snappableToSubSnappableMap[$WorkloadType] | Where-Object {
+        ($_.NameSuffix -eq $SubWorkloadType) -or ($SubWorkloadType -eq "")
+    } | ForEach-Object -Process {
+        $recoveryName=$Name+"_"+$_.NameSuffix
+        $baseInfo = @{
+            "snappableType" = $_.SnappableType;
+            "subSnappableType" = $_.SubSnappableType;
+            "recoverySpec" = @{
+                "recoveryPoint" = $rpMilliseconds;
+                "srcSubscriptionId" = $subscriptionId;
+                "targetSubscriptionId" = $subscriptionId;
+                "operationalRecoverySpec" = $_.OperationalRecoverySpec
+            }
+        }
+
+        $o365GroupSelectorWithRecoverySpec = @{
+            "baseInfo" = $baseInfo;
+            "adGroupId" = $AdGroupId;
+        }
+
+        $payload = @{
+            "operationName" = "StartBulkRecovery";
+            "variables"     = @{
+                "input" = @{
+                    "definition" = @{
+                        "name" = $recoveryName;
+                        "o365GroupSelectorWithRecoverySpec" = $o365GroupSelectorWithRecoverySpec;
+                        "recoveryMode" = "AD_HOC";
+                        "failureAction" = "IGNORE_AND_CONTINUE";
+                        "recoveryDomain" = "O365";
+                    };
+                };
+            };
+            "query" = "mutation StartBulkRecovery(`$input: StartBulkRecoveryInput!) {
+                startBulkRecovery(input: `$input) {
+                  bulkRecoveryInstanceId
+                  taskchainId
+                  jobId
+                  error
+                }
+              }";
+        }
+
+        $response = Invoke-RestMethod -Method POST -Uri $endpoint -Body $($payload | ConvertTo-JSON -Depth 100) -Headers $headers
+        if ($null -eq $response) {
+            return
+        }
+        if ($response.errors) {
+            $response = $response.errors[0].message
+            Write-Host "Error starting operational recovery $recoveryName. The error response is $($response).`n"
+            return
+        }
+
+        $row = '' | Select-Object massRecoveryInstanceID,taskchainID, jobID, error
+        $row.massRecoveryInstanceId = $response.data.startBulkRecovery.bulkRecoveryInstanceId
+        $row.taskchainID = $response.data.startBulkRecovery.taskchainId
+        $row.jobID = $response.data.startBulkRecovery.jobId
+        $row.error = $response.data.startBulkRecovery.error
+
+        Write-Host "Started operational recovery $recoveryName with the following details:"
+        Write-Host $row
+        Write-Host "`n"
+    }
+
+    return
+}
+Export-ModuleMember -Function Start-OperationalRecovery

--- a/RubrikPolaris/RubrikPolaris.psd1
+++ b/RubrikPolaris/RubrikPolaris.psd1
@@ -88,10 +88,12 @@ FunctionsToExport = @(
     'Start-MassRecovery',
     'Get-MassRecoveryProgress',
     'Stop-MassRecovery',
+    'Start-OperationalRecovery',
     'Restore-PolarisM365Exchange',
     'Get-PolarisM365ExchangeSnapshot'
     'Get-PolarisM365OneDrive'
     'Remove-EnterpriseApplication'
+    
 
 
 )


### PR DESCRIPTION
# Description

In this PR we add new endpoints for the new feature operational recovery

```
PS> Start-OperationalRecovery -Name $name -RecoveryPoint $recoveryPoint -SubscriptionName $subscriptionName -AdGroupId $adGroupId 
-WorkloadType $workloadType # only "Exchange" is valid -MailboxFromTime $mailboxFromTime -MailboxUntilTime $mailboxUntilTime 

PS>  Start-OperationalRecovery -Name $name -RecoveryPoint $recoveryPoint -SubscriptionName $subscriptionName -AdGroupId $adGroupId 
-WorkloadType $workloadType # only "Exchange" is valid -ArchiveFolderAction $archiveFolderAction
```


## Related Issue

<!-- Please link to the issue here-->

<!-- If no issue exsits for your pull request, please use a draft pull requests for discussion purposes-->

## Motivation and Context

As we are going to release operational recovery for beta, we need add support for these in powershell.

## How Has This Been Tested?

Have tested out all the cases of failed/succeeded operational recovery at various points of time.

## Screenshots (if appropriate):
Missing arguements:
<img width="1417" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/322eab6a-43e4-470f-a637-84adcf73d9af">

Start Operational Recovery with the mailbox time range
<img width="1423" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/e766bebc-c8c4-4e61-a6ad-213dde792c95">
<img width="1145" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/9cb2c0fc-8a9b-4fc6-b0f8-c09ef2a6610f">

Operational Recovery for Mailbox succeeds, and time range is set as input 
<img width="1265" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/dd567a53-773b-4f28-97a1-49a548366bb8">

Operation Recovery for Calendar succeeds, and time range is set as expected, two weeks from now
<img width="1281" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/20643fe5-f053-4ca5-9cc8-cfd1690d1a81">

Start Operational Recovery with the archive folder action set "Exclude Archive"
<img width="1394" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/49c812f4-0fbc-4868-a557-70e854221c86">

<img width="1276" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/1a4758f0-5ea2-4e8e-affa-d24ae0ea998c">


## Types of changes



What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.