### PR TITLE
Add Start Complete Operational Recovery endpoints

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -44,6 +44,8 @@ The following commands are available in the module:
 * `Start-MassRecovery`
 * `Stop-MassRecovery`
 * `Get-MassRecoveryProgress`
+* `Start-OperationalRecovery`
+* `Start-CompleteOperationalRecovery`
 
 Each command has help which describes their usage and parameters, these can be seen using the `Get-Help <command>` command within PowerShell.
 

--- a/RubrikPolaris/M365/Start-CompleteOperationalRecovery.ps1
+++ b/RubrikPolaris/M365/Start-CompleteOperationalRecovery.ps1
@@ -1,0 +1,109 @@
+function Start-CompleteOperationalRecovery() {
+    <#
+    .SYNOPSIS
+    Starts complete operational recovery 
+    
+    .DESCRIPTION
+    Starts the complete operational recovery with a given initial operation recovery instance ID and M365 subscription Name.
+
+    .PARAMETER MassRecoveryInstanceId
+    The instance ID of initial operational recovery you wish to complete .
+
+    .PARAMETER SubscriptionName
+    The subscription name for the initial operational recovery you wish to complete.
+
+    .INPUTS
+    None. You cannot pipe objects to Start-CompleteOperationalRecovery().
+   
+    .OUTPUTS
+    System.Object. The taskchainID, massRecoveryInstanceID, error, jobID and recoveryName for 
+    the complete operational recovery job.  
+ 
+    .EXAMPLE
+    PS> Start-CompleteOperationalRecovery -MassRecoveryInstanceId $massRecoveryInstanceId -SubscriptionName $subscriptionName
+    #>
+
+    param(
+        [Parameter(Mandatory=$True)]
+        [String]$MassRecoveryInstanceId,
+        [Parameter(Mandatory=$True)]
+        [String]$SubscriptionName,
+        [String]$Token = $global:RubrikPolarisConnection.accessToken,
+        [String]$PolarisURL = $global:RubrikPolarisConnection.PolarisURL
+    )
+
+    if((Test-IsGuid $MassRecoveryInstanceId) -eq $False) {
+      Write-Host "Error starting complete operational recovery with instance ID $MassRecoveryInstanceId. The error response is 'instance ID is not a valid UUID'."
+      return
+    }
+
+    $headers = @{
+        'Content-Type' = 'application/json';
+        'Accept' = 'application/json';
+        'Authorization' = $('Bearer '+$Token);
+    }
+
+    $endpoint = $PolarisURL + '/api/graphql'
+
+    $subscriptionId = getSubscriptionId($SubscriptionName)
+
+    Write-Information -Message "Starting complete operational recovery with instance ID $MassRecoveryInstanceId."
+
+    $payload = @{
+        "operationName" = "CompleteOperationalRecovery";
+        "variables"     = @{
+            "input" = @{
+              "bulkRecoveryInstanceId" = $MassRecoveryInstanceId;
+              "subscriptionId" = $subscriptionId;
+            };
+          };
+        "query" = "mutation CompleteOperationalRecovery(`$input: CompleteOperationalRecoveryInput!) {
+            completeOperationalRecovery(input: `$input) {
+              bulkRecoveryInstanceId
+              taskchainId
+              recoveryName
+              error
+              jobId   
+          }
+        }";
+    }
+
+    $response = Invoke-RestMethod -Method POST -Uri $endpoint -Body $($payload | ConvertTo-JSON -Depth 100) -Headers $headers
+    
+    if ($null -eq $response) {
+      return 
+    }
+
+    if ($response.errors) {
+      $response = $response.errors[0].message
+      Write-Host "Error starting complete operational recovery with instance ID $MassRecoveryInstanceId. The error response is $($response)."
+      return
+    }
+
+    $row = '' | Select-Object massRecoveryInstanceID,taskchainID, jobID, error
+    $row.massRecoveryInstanceId = $response.data.completeOperationalRecovery.bulkRecoveryInstanceId
+    $row.taskchainID = $response.data.completeOperationalRecovery.taskchainId
+    $row.jobID = $response.data.completeOperationalRecovery.jobId
+    $row.error = $response.data.completeOperationalRecovery.error
+
+    $recoveryName = $response.data.completeOperationalRecovery.recoveryName
+
+    Write-Host "Started mass recovery $recoveryName with the following details:"
+    Write-Host $row
+    Write-Host "`n"
+    return
+}
+Export-ModuleMember -Function Start-CompleteOperationalRecovery
+
+function Test-IsGuid
+{
+    [OutputType([bool])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$StringGuid
+    )
+
+   $ObjectGuid = [System.Guid]::empty
+   return [System.Guid]::TryParse($StringGuid,[System.Management.Automation.PSReference]$ObjectGuid) # Returns True if successfully parsed
+}

--- a/RubrikPolaris/RubrikPolaris.psd1
+++ b/RubrikPolaris/RubrikPolaris.psd1
@@ -89,6 +89,7 @@ FunctionsToExport = @(
     'Get-MassRecoveryProgress',
     'Stop-MassRecovery',
     'Start-OperationalRecovery',
+    'Start-CompleteOperationalRecovery',
     'Restore-PolarisM365Exchange',
     'Get-PolarisM365ExchangeSnapshot'
     'Get-PolarisM365OneDrive'


### PR DESCRIPTION
# Description
In this PR we add new endpoints for start complete operational recovery
```
PS> Start-CompleteOperationalRecovery -MassRecoveryInstanceId $massRecoveryInstanceId -SubscriptionName $subscriptionName
```

## Related Issue

<!-- Please link to the issue here-->

<!-- If no issue exsits for your pull request, please use a draft pull requests for discussion purposes-->

## Motivation and Context

As we are going to release operational recovery in beta, we have added support for these in powershell.

## How Has This Been Tested?

Have tested out all the cases of failed/succeeded complete operational recovery.

## Screenshots (if appropriate):
failed case:
<img width="1384" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/d2bebd71-2aeb-409c-9f8f-46ede0b786cb">
Trigger complete operational recovery for calendar successfully
<img width="1421" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/13e72d9a-bac2-4c5d-99c2-24d92678fbf9">

<img width="1010" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/359b17c6-23fb-4f15-9b4f-c0e94a1515c7">


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.