### PR TITLE
Update the script with recovery stage enum

### DIFF
--- a/RubrikPolaris/M365/Start-CompleteOperationalRecovery.ps1
+++ b/RubrikPolaris/M365/Start-CompleteOperationalRecovery.ps1
@@ -47,7 +47,8 @@ function Start-CompleteOperationalRecovery() {
 
     $subscriptionId = getSubscriptionId($SubscriptionName)
 
-    Write-Information -Message "Starting complete operational recovery with instance ID $MassRecoveryInstanceId."
+    Write-Host "Starting complete operational recovery with instance ID $MassRecoveryInstanceId."
+    Write-Host "`n"
 
     $payload = @{
         "operationName" = "CompleteOperationalRecovery";
@@ -88,7 +89,7 @@ function Start-CompleteOperationalRecovery() {
 
     $recoveryName = $response.data.completeOperationalRecovery.recoveryName
 
-    Write-Host "Started mass recovery $recoveryName with the following details:"
+    Write-Host "Started complete operational recovery $recoveryName with the following details:"
     Write-Host $row
     Write-Host "`n"
     return

--- a/RubrikPolaris/M365/Start-OperationalRecovery.ps1
+++ b/RubrikPolaris/M365/Start-OperationalRecovery.ps1
@@ -8,8 +8,8 @@ function Start-OperationalRecovery() {
     given recovery point in time using the mailboxTimeRange.
 
     .PARAMETER Name
-    The name of the operational recovery you wish to choose. 
-
+    The name of the operational recovery you wish to choose.
+   
     .PARAMETER RecoveryPoint
     The date time you wish to use to restore closest earlier backups. The format
     is "YYYY-MM-DD HH:MM:SS"
@@ -90,7 +90,7 @@ function Start-OperationalRecovery() {
     }    
 
     $calendarFromTime = (Get-Date).AddDays(-14) | Get-Date -format s
-    Write-Host "Start Operational Recovery using MailboxTimeRange fromTime: $MailboxFromTime, untilTime: $MailboxUntilTime and CalendarTime Range fromTime: $calendarFromTime.`n"
+    Write-Host "Starting Operational Recovery $Name using MailboxTimeRange fromTime: $MailboxFromTime, untilTime: $MailboxUntilTime and CalendarTime Range fromTime: $calendarFromTime.`n"
 
     $snappableToSubSnappableMap = @{
         "Exchange" = @(
@@ -105,7 +105,8 @@ function Start-OperationalRecovery() {
                             "untilTime" = $MailboxUntilTime;
                         };
                         "archiveFolderAction" = $ArchiveFolderAction;
-		    }
+		    };
+                   "operationalRecoveryStage" = "INITIAL_OPERATIONAL_RECOVERY";
                 };
             };
             @{
@@ -118,6 +119,7 @@ function Start-OperationalRecovery() {
                             "fromTime" = $calendarFromTime 
                         }; 
                     };
+                   "operationalRecoveryStage" = "INITIAL_OPERATIONAL_RECOVERY";
                 };
             };
             @{
@@ -146,7 +148,7 @@ function Start-OperationalRecovery() {
         ($_.NameSuffix -eq $SubWorkloadType) -or ($SubWorkloadType -eq "")
     } | ForEach-Object -Process {
         $recoveryName=$Name+"_"+$_.NameSuffix
-        $baseInfo = @{
+	$baseInfo = @{
             "snappableType" = $_.SnappableType;
             "subSnappableType" = $_.SubSnappableType;
             "recoverySpec" = @{


### PR DESCRIPTION
# Description

This diff is to pass the recovery stage enum when start the operational recovery.

## Related Issue

<!-- Please link to the issue here-->

<!-- If no issue exsits for your pull request, please use a draft pull requests for discussion purposes-->

## Motivation and Context

As we are going to release operational recovery in beta, we have added support for these in powershell.

## How Has This Been Tested?

Have tested out all the cases of failed/succeeded complete operational recovery.

## Screenshots (if appropriate):
<img width="1446" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/9992fbde-6d0a-43bb-b32a-b520542f598d">

The recovery stage was persisted in opreational recovery spec.

<img width="1308" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/564b8f7e-6184-430b-9fc6-74a1ad9b743c">


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.