### PR TITLE
Add inplace recovery support for operational recovery

### DIFF
--- a/RubrikPolaris/M365/Start-OperationalRecovery.ps1
+++ b/RubrikPolaris/M365/Start-OperationalRecovery.ps1
@@ -48,6 +48,9 @@ function Start-OperationalRecovery() {
 
     .PARAMETER ShouldSkipItemPermission
     The Action of skip item permission you wish to use to restore site.
+ 
+    .PARAMETER InplaceRecovery
+    The Action of recover objects to original location and overwrite duplicates.
 
     .PARAMETER SubWorkloadType
     The type of sub workload you wish to restore. Only supported for "Exchange"
@@ -94,6 +97,8 @@ function Start-OperationalRecovery() {
         [DateTime]$SharepointUntilTime,
         [Parameter(Mandatory=$False)]
         [Boolean]$ShouldSkipItemPermission,
+        [Parameter(Mandatory=$True)]
+        [Boolean]$InplaceRecovery,
         [Parameter(Mandatory=$False)]
         [ValidateSet("Mailbox", "Calendar", "Contacts")]
         [String]$SubWorkloadType,
@@ -203,6 +208,14 @@ function Start-OperationalRecovery() {
   
     $subscriptionId = getSubscriptionId($SubscriptionName)
   
+    $inplaceRecoverySpec = @{
+        "nameCollisionRule" = "OVERWRITE";
+    }
+
+    if ($InplaceRecovery -eq $False) {
+        $inplaceRecoverySpec = $null
+    } 
+
     $snappableToSubSnappableMap[$WorkloadType] | Where-Object {
         ($_.NameSuffix -eq $SubWorkloadType) -or ($SubWorkloadType -eq "")
     } | ForEach-Object -Process {
@@ -214,7 +227,8 @@ function Start-OperationalRecovery() {
                 "recoveryPoint" = $rpMilliseconds;
                 "srcSubscriptionId" = $subscriptionId;
                 "targetSubscriptionId" = $subscriptionId;
-                "operationalRecoverySpec" = $_.OperationalRecoverySpec
+                "operationalRecoverySpec" = $_.OperationalRecoverySpec;
+                "inplaceRecoverySpec" = $inplaceRecoverySpec;
             }
         }
 


### PR DESCRIPTION
# Description

The diff is to add in-place recovery spec to the operational recovery. 
## Motivation and Context

 This is consistent with RSC and provide users the flexibility to restore data in-place.

## Motivation and Context

## How Has This Been Tested?
Manual trigger the operational recovery, and verify.

## Screenshots (if appropriate):
![152301718907291_ pic](https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/e94c7284-7515-4d4d-aa2b-dcdb87e9ac14)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.