### PR TITLE
Add in-place support for mass recovery 

### DIFF
--- a/RubrikPolaris/M365/Start-MassRecovery.ps1
+++ b/RubrikPolaris/M365/Start-MassRecovery.ps1
@@ -60,6 +60,8 @@ function Start-MassRecovery() {
         [Parameter(Mandatory=$True)]
         [ValidateSet("OneDrive", "Exchange", "Sharepoint")]
         [String]$WorkloadType,
+        [Parameter(Mandatory=$True)]
+        [Boolean]$InplaceRecovery,
         [Parameter(Mandatory=$False)]
         [ValidateSet("Mailbox", "Calendar", "Contacts")]
         [String]$SubWorkloadType,
@@ -82,12 +84,20 @@ function Start-MassRecovery() {
         return
     }
 
+    $InplaceRecoverySpec = @{
+        "nameCollisionRule" = "OVERWRITE";
+    }
+    if ($InplaceRecovery -eq $False) { 
+        $InplaceRecoverySpec = $null
+    }
+
     $snappableToSubSnappableMap = @{
         "OneDrive" = @(
             @{
                 SnappableType = "O365_ONEDRIVE";
                 SubSnappableType = "NONE";
                 NameSuffix="OneDrive";
+                InplaceRecoverySpec = $null;
             }
         );
         "Exchange" = @(
@@ -95,16 +105,19 @@ function Start-MassRecovery() {
                 SnappableType = "O365_EXCHANGE";
                 SubSnappableType = "O365_MAILBOX";
                 NameSuffix="Mailbox";
+                InplaceRecoverySpec = $InplaceRecoverySpec;               
             };
             @{
                 SnappableType = "O365_EXCHANGE";
                 SubSnappableType = "O365_CALENDAR";
                 NameSuffix="Calendar";
+                InplaceRecoverySpec = $InplaceRecoverySpec;
             };
             @{
                 SnappableType = "O365_EXCHANGE";
                 SubSnappableType = "O365_CONTACT";
                 NameSuffix="Contacts";
+                InplaceRecoverySpec = $InplaceRecoverySpec;
             };
         );
         "Sharepoint" = @(
@@ -112,6 +125,7 @@ function Start-MassRecovery() {
                 SnappableType = "O365_SHAREPOINT";
                 SubSnappableType = "NONE";
                 NameSuffix="Sharepoint";
+                InplaceRecoverySpec = $InplaceRecoverySpec;
             }
         );
     }
@@ -140,6 +154,7 @@ function Start-MassRecovery() {
                 "recoveryPoint" = $rpMilliseconds;
                 "srcSubscriptionId" = $subscriptionId;
                 "targetSubscriptionId" = $subscriptionId;
+                "inplaceRecoverySpec" = $_.InplaceRecoverySpec;
             }
         }
 


### PR DESCRIPTION
# Description

This diff is to add in-place support for start mass recovery using powershell.

## Motivation and Context
Previously we dont support in-place for mass recovery, since we already supported for Exchange and Sharepoint and it is available in RSC, we should keep pwsh scripts updated, consistent with RSC. 
Will remove hardcode variable for OneDrive once we support in-place for it also.

## How Has This Been Tested?
Manually triggered the mass recovery via pwsh script.

## Screenshots (if appropriate):
<img width="1074" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/825f6324-9145-417e-bfee-9b36a4703888">

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.