### PR TITLE
Remove inplace for sharepoint Mass Recovery

### DIFF
--- a/RubrikPolaris/M365/Start-MassRecovery.ps1
+++ b/RubrikPolaris/M365/Start-MassRecovery.ps1
@@ -60,7 +60,7 @@ function Start-MassRecovery() {
         [Parameter(Mandatory=$True)]
         [ValidateSet("OneDrive", "Exchange", "Sharepoint")]
         [String]$WorkloadType,
-        [Parameter(Mandatory=$True)]
+        [Parameter(Mandatory=$False)]
         [Boolean]$InplaceRecovery,
         [Parameter(Mandatory=$False)]
         [ValidateSet("Mailbox", "Calendar", "Contacts")]
@@ -84,11 +84,12 @@ function Start-MassRecovery() {
         return
     }
 
-    $InplaceRecoverySpec = @{
-        "nameCollisionRule" = "OVERWRITE";
-    }
-    if ($InplaceRecovery -eq $False) { 
-        $InplaceRecoverySpec = $null
+    $InplaceRecoverySpec = $null
+
+    if ($InplaceRecovery -eq $True) {
+        $InplaceRecoverySpec = @{
+            "nameCollisionRule" = "OVERWRITE";
+        }
     }
 
     $snappableToSubSnappableMap = @{
@@ -97,7 +98,6 @@ function Start-MassRecovery() {
                 SnappableType = "O365_ONEDRIVE";
                 SubSnappableType = "NONE";
                 NameSuffix="OneDrive";
-                InplaceRecoverySpec = $null;
             }
         );
         "Exchange" = @(
@@ -125,7 +125,6 @@ function Start-MassRecovery() {
                 SnappableType = "O365_SHAREPOINT";
                 SubSnappableType = "NONE";
                 NameSuffix="Sharepoint";
-                InplaceRecoverySpec = $InplaceRecoverySpec;
             }
         );
     }


### PR DESCRIPTION
# Description
 The PR will remove the in-place support for sharepoint mass recovery, which is also not supported from RSC.

## Motivation and Context

Keep consistent with the behavior in RSC.

## How Has This Been Tested?
Manual test
<img width="1058" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/a60c7e01-b73d-4a2e-8f40-2a4376378a95">


<img width="1017" alt="image" src="https://github.com/rubrikinc/polaris-o365-powershell/assets/16889822/218bd3d2-08f2-4973-9985-00a3643b60ee">


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.